### PR TITLE
fix: use buildah-task image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-user-workloads/cqi-tenant/source-build-this-is-a-parent-image/source-build-this-is-a-parent-image:d6fbcc2deb643e5011030dc7dde3d092a2d6d5cf@sha256:3b3eea2d6ebf5236fca54a857f68d40702225c7d2b3a49d667c43f3a8d53ceef
+FROM quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
 
 WORKDIR /src
 COPY main.py .


### PR DESCRIPTION
since `buildah-task` image is built by konflux, it should serve the purpose sample repo trying to acheive